### PR TITLE
Show level 1 taxons' sub topics

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -2,4 +2,8 @@ class TopicsController < ApplicationController
   def index
     @level_one_taxons = Taxons.new.level_one_taxons
   end
+
+  def show
+    @taxon = Taxon.new(params[:path])
+  end
 end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -1,0 +1,19 @@
+class Taxon
+  def initialize(base_path)
+    @base_path = base_path
+  end
+
+  def title
+    content_item["title"]
+  end
+
+  private
+
+  def content_item
+    @content_item ||= Services.content_store.content_item(base_path)
+  end
+
+  def base_path
+    "/#{@base_path}"
+  end
+end

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -7,6 +7,14 @@ class Taxon
     content_item["title"]
   end
 
+  def child_taxons
+    content_item.dig("links", "child_taxons")
+  end
+
+  def children?
+    child_taxons.present?
+  end
+
   private
 
   def content_item

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -4,7 +4,7 @@
   <ul>
     <% @level_one_taxons.each do |taxon| %>
       <li>
-        <%= link_to(taxon["title"], taxon["base_path"] ) %>
+        <%= link_to(taxon["title"], "/topics/#{taxon["base_path"]}" ) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -4,7 +4,7 @@
   <ul>
     <% @level_one_taxons.each do |taxon| %>
       <li>
-        <%= link_to(taxon["title"], "/topics/#{taxon["base_path"]}" ) %>
+        <%= link_to(taxon["title"], "/topics#{taxon["base_path"]}" ) %>
       </li>
     <% end %>
   </ul>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,1 +1,13 @@
 <%= render "govuk_component/title", title: @taxon.title %>
+
+<div>
+  <ul>
+    <% if @taxon.children? %>
+      <% @taxon.child_taxons.each do |child_taxon| %>
+        <li>
+          <%= link_to(child_taxon["title"], "/topics#{child_taxon["base_path"]}" ) %>
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,0 +1,1 @@
+<%= render "govuk_component/title", title: @taxon.title %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
   get "/", to: "welcome#index"
   get "/topics", to: "topics#index"
 
+  get "/topics/*path", to: "topics#show"
+
   root to: "topics#index"
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,10 @@
 require 'gds_api/content_store'
 
 module Services
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.current.find("content-store"))
+  end
+
   def self.root_taxons
     @root_taxons ||= YAML.load_file(Rails.root.join("lib", "data", "root_taxons.yml"))
   end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -14,4 +14,18 @@ RSpec.describe TopicsController, type: :controller do
       expect(subject).to render_template("topics/index")
     end
   end
+
+  describe "GET #show" do
+    it "returns success when passed valid path for a taxon" do
+      get :show, params: { path: "foo/bar" }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "renders the :show template" do
+      get :show, params: { path: "foo/bar" }
+
+      expect(subject).to render_template("topics/show")
+    end
+  end
 end

--- a/spec/model/taxon_spec.rb
+++ b/spec/model/taxon_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe Taxon, type: :model do
+  include GdsApi::TestHelpers::ContentStore
+
+  describe "#content_item" do
+    before(:each) do
+      example_schema_string = GovukContentSchemaTestHelpers::Examples.new.get('taxon', 'taxon_with_child_taxons')
+      @example_schema = JSON.parse(example_schema_string)
+    end
+
+    it "should return content item title" do
+      allow(Services.content_store).to receive(:content_item).with("/education").and_return(@example_schema)
+
+      topic_taxon = Taxon.new("education")
+      expect(topic_taxon.title).to eq("Taxon with children")
+    end
+  end
+end
+

--- a/spec/model/taxon_spec.rb
+++ b/spec/model/taxon_spec.rb
@@ -8,13 +8,42 @@ RSpec.describe Taxon, type: :model do
     before(:each) do
       example_schema_string = GovukContentSchemaTestHelpers::Examples.new.get('taxon', 'taxon_with_child_taxons')
       @example_schema = JSON.parse(example_schema_string)
+      @topic_taxon = Taxon.new("education")
     end
 
     it "should return content item title" do
       allow(Services.content_store).to receive(:content_item).with("/education").and_return(@example_schema)
 
-      topic_taxon = Taxon.new("education")
-      expect(topic_taxon.title).to eq("Taxon with children")
+      expect(@topic_taxon.title).to eq("Taxon with children")
+    end
+
+    it "should return associated child taxons" do
+      allow(Services.content_store).to receive(:content_item).with("/education").and_return(@example_schema)
+
+      child_taxons = @topic_taxon.child_taxons
+
+      expect(child_taxons.length).to eq(1)
+      expect(child_taxons.first["title"]).to eq("Further and higher education, skills and vocational training")
+    end
+  end
+
+  describe "#children?" do
+    before(:each) do
+      @topic_taxon = Taxon.new("education")
+    end
+
+    it "should indicate that taxon has child taxons" do
+      example_schema_with_children = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('taxon', 'taxon_with_child_taxons'))
+      allow(Services.content_store).to receive(:content_item).with("/education").and_return(example_schema_with_children)
+
+      expect(@topic_taxon.children?).to be_truthy
+    end
+
+    it "should indicate that taxon does not have child taxons" do
+      example_schema_without_children = JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get('taxon', 'taxon'))
+      allow(Services.content_store).to receive(:content_item).with("/education").and_return(example_schema_without_children)
+
+      expect(@topic_taxon.children?).to be_falsey
     end
   end
 end

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,0 +1,6 @@
+require "govuk-content-schema-test-helpers"
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'frontend'
+  config.project_root = Rails.root
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/MXTW3NjA/34-create-the-sub-topic-pages-prototype

Depends on https://github.com/alphagov/govuk-content-schemas/pull/707 which adds a taxon_with_child_taxons example to content schemas.