### PR TITLE
Add document format label to content items

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,9 +8,23 @@ body {
   @include core-19;
 }
 
- h2 {
+h2 {
   margin: $gutter 0 $gutter-one-third;
   @include bold-24;
+}
+
+ul {
+  li {
+  list-style-type: none;
+  margin: 5px 0
+  }
+}
+
+.topics-document-type-stats {
+  background-color: $grey-3;
+  padding: 2px 5px;
+  border-radius: 5px;
+  font-size: 14px;
  }
 
 .sub-topics-tagged-content-count {

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -1,0 +1,17 @@
+module TopicsHelper
+  def document_type_count(tagged_content)
+    document_count = {}
+
+    tagged_content.each do |content_item|
+      document_format = content_item["format"]
+
+      if document_count.has_key?(content_item["format"])
+        document_count[document_format] = document_count[document_format] + 1
+      else
+        document_count[document_format] = 1
+      end
+    end
+
+    document_count.sort_by {|_key, value| value}.reverse.to_h
+  end
+end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -21,6 +21,7 @@
       <% @tagged_content.search_results.each do |content_item| %>
         <li>
           <%= link_to(content_item["title"], "#{content_item["link"]}" ) %>
+          <span class="topics-document-type-stats"><%= content_item["format"] %></span>
         </li>
       <% end %>
     </ul>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -17,6 +17,16 @@
 <div>
   <% if @tagged_content.search_results_count > 0 %>
     <h2>Content Items - <%= @tagged_content.search_results_count %></h2>
+    <div class="topics-document-type-stats topics-document-type-list">
+      <ul>
+        <% document_type_count(@tagged_content.search_results).each do |document_type, count| %>
+          <li>
+            <%= document_type %>: <%= count %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
     <ul>
       <% @tagged_content.search_results.each do |content_item| %>
         <li>

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe TopicsHelper do
+  describe "#document_type_count" do
+    it "should return total counts for document types" do
+      mock_tagged_content = [
+        {
+        "format" => "publication",
+        "link" => "/government/publications/esfa-update-january-2017",
+        "title"=>"ESFA update: January 2017"
+      },
+      {
+        "format" => "publication",
+        "link" => "/government/publications/esfa-update-january-2018",
+        "title"=>"ESFA update: January 2018"
+      }
+    ]
+
+    document_count = document_type_count(mock_tagged_content)
+
+    expect(document_count["publication"]).to eq(2)
+    end
+  end
+end

--- a/spec/model/rummager_search_spec.rb
+++ b/spec/model/rummager_search_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RummagerSearch, type: :model do
 
       results = RummagerSearch.new("12345").search_results
 
-      results_keys = ["title", "link"].sort
+      results_keys = ["title", "link", "format"].sort
       results.each do |result|
         expect(result.keys).to include(*results_keys)
       end

--- a/spec/support/helpers/services_request_helpers.rb
+++ b/spec/support/helpers/services_request_helpers.rb
@@ -25,11 +25,13 @@ module ServicesRequestHelpers
       "results" => [
         {
           "title" => "A Tagged Content",
-          "link" => "/link/to/content"
+          "link" => "/link/to/content",
+          "format" => "guide"
         },
         {
           "title" => "Second Tagged Content",
-          "link" => "/another/link"
+          "link" => "/another/link",
+          "format" => "publication"
         }
       ],
       "total" => 2


### PR DESCRIPTION
Trello: https://trello.com/c/8T0vS9RW/44-add-the-document-type-to-the-list-of-content-items

<img width="1019" alt="screenshot showing document type labels against each content item, and a summary at the top" src="https://user-images.githubusercontent.com/29889908/35742755-63538698-0833-11e8-9519-99d6edb33fda.png">


