### PR TITLE
Group content items by document type

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,3 +33,16 @@ ul {
   border-radius: 5px;
   font-size: 14px;
  }
+
+.tagged-content-groups {
+  margin: $gutter 0 0;
+}
+
+.document-type-group-list {
+  margin: 0 0 $gutter;
+}
+
+h3 {
+  margin-bottom: $gutter-one-third;
+  @include bold-19;
+}

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -14,4 +14,20 @@ module TopicsHelper
 
     document_count.sort_by {|_key, value| value}.reverse.to_h
   end
+
+  def grouped_tagged_content(tagged_content)
+    grouped_content = {}
+    
+    tagged_content.each do |content_item|
+      document_format = content_item["format"]
+
+      if grouped_content.has_key? document_format
+        grouped_content[document_format] << content_item
+      else
+        grouped_content[document_format] = [content_item]
+      end
+    end
+
+    grouped_content.sort_by {|_key, value| value.count}.reverse.to_h
+  end
 end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -27,13 +27,19 @@
       </ul>
     </div>
 
-    <ul>
-      <% @tagged_content.search_results.each do |content_item| %>
-        <li>
-          <%= link_to(content_item["title"], "#{content_item["link"]}" ) %>
-          <span class="topics-document-type-stats"><%= content_item["format"] %></span>
-        </li>
+    <div class="tagged-content-groups">
+      <% grouped_tagged_content(@tagged_content.search_results).each do |document_type, content_items| %>
+        <div class="document-type-group-list">
+          <h3><%= document_type.humanize %>:</h3>
+          <ul>
+            <% content_items.each do |item| %>
+              <li>
+                <%= link_to(item["title"], "#{item["link"]}" ) %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
       <% end %>
-    </ul>
+    </div>
   <% end %>
 </div>

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -1,24 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe TopicsHelper do
+  include TaggedContentHelpers
+
   describe "#document_type_count" do
     it "should return total counts for document types" do
-      mock_tagged_content = [
+      mock_tagged_content = mocked_tagged_content
+
+      document_count = document_type_count(mock_tagged_content)
+
+      expect(document_count["publication"]).to eq(2)
+    end
+  end
+
+  describe "#group_tagged_content" do
+    it "should group the tagged content by document type" do
+      tagged_content = mocked_tagged_content
+
+      grouped_tagged_content = grouped_tagged_content(tagged_content)
+
+      expect(grouped_tagged_content.keys().length).to eq(3)
+
+      expected_groups = %w[publication news_article organisation].sort
+      expect(grouped_tagged_content.keys()).to include(*expected_groups)
+
+      expect(grouped_tagged_content["news_article"]).to include(
         {
-        "format" => "publication",
-        "link" => "/government/publications/esfa-update-january-2017",
-        "title"=>"ESFA update: January 2017"
-      },
-      {
-        "format" => "publication",
-        "link" => "/government/publications/esfa-update-january-2018",
-        "title"=>"ESFA update: January 2018"
-      }
-    ]
+          "format" => "news_article",
+          "link" => "/government/news/education-bill-receives-royal-assent",
+          "title"=>"Education Bill receives Royal Assent"
+        }
+      )
 
-    document_count = document_type_count(mock_tagged_content)
-
-    expect(document_count["publication"]).to eq(2)
+      expect(grouped_tagged_content.find_index { |k,_| k == "publication" }).to eq(0)
     end
   end
 end

--- a/spec/support/helpers/tagged_content_helpers.rb
+++ b/spec/support/helpers/tagged_content_helpers.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+module TaggedContentHelpers
+  def mocked_tagged_content
+    [
+        {
+            "format" => "publication",
+            "link" => "/government/publications/esfa-update-january-2017",
+            "title"=>"ESFA update: January 2017"
+        },
+        {
+            "format" => "publication",
+            "link" => "/government/publications/esfa-update-january-2018",
+            "title"=>"ESFA update: January 2018"
+        },
+        {
+            "format" => "news_article",
+            "link" => "/government/news/education-bill-receives-royal-assent",
+            "title"=>"Education Bill receives Royal Assent"
+        },
+        {
+            "format" => "organisation",
+            "link" => "/government/organisations/department-for-education",
+            "title"=>"Department for Education"
+        }
+    ]
+  end
+end
+


### PR DESCRIPTION
The heroku app of this PR can be found here:
https://govuk-topic-pages-protot-pr-13.herokuapp.com/topics/childcare-parenting

<img width="1007" alt="screen shot 2018-02-09 at 15 21 33" src="https://user-images.githubusercontent.com/20514501/36034785-0e62365a-0dad-11e8-9cbe-b89d897998a0.png">

In the PR I added the functionality for the tagged content to be grouped by document type. In the future I think that we will be changing how the content is grouped on topic pages, but we decided to group them by doc type for the time being as the exact nature of grouping is currently undecided.

https://trello.com/c/ijfAWwLq/57-break-tagged-content-on-topic-pages-into-groups
