### PR TITLE
Use rummage’s search-enum method to return all tagged content

### DIFF
--- a/app/models/rummager_search.rb
+++ b/app/models/rummager_search.rb
@@ -9,17 +9,17 @@ class RummagerSearch
   end
 
   def search_results
-    @search_results = rummager_search["results"]
+    @search_results = rummager_search
   end
 
   def search_results_count
-    @results_count = rummager_search["total"]
+    @results_count = rummager_search.count
   end
 
   private
 
   def rummager_search
-    @rummager_results ||= Services.rummager.search(search_params)
+    @rummager_results ||= Services.rummager.search_enum(search_params, page_size: PAGE_SIZE_TO_GET_EVERYTHING)
   end
 
   def search_params

--- a/spec/model/rummager_search_spec.rb
+++ b/spec/model/rummager_search_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RummagerSearch, type: :model do
       results.each do |result|
         expect(result.keys).to include(*results_keys)
       end
-      expect(results.length).to eq(2)
+      expect(results.count).to eq(2)
     end
   end
 

--- a/spec/support/helpers/services_request_helpers.rb
+++ b/spec/support/helpers/services_request_helpers.rb
@@ -5,26 +5,23 @@ module ServicesRequestHelpers
   include GdsApi::TestHelpers::Rummager
 
   def stub_rummager
-    allow(Services.rummager).to receive(:search).and_return(rummager_results)
+    allow(Services.rummager).to receive(:search_enum).and_return(rummager_results)
   end
 
   private
 
   def rummager_results
-    {
-      "results" => [
-        {
-          "title" => "A Tagged Content",
-          "link" => "/link/to/content",
-          "format" => "guide"
-        },
-        {
-          "title" => "Second Tagged Content",
-          "link" => "/another/link",
-          "format" => "publication"
-        }
-      ],
-      "total" => 2
-    }
+    [
+      {
+        "title" => "A Tagged Content",
+        "link" => "/link/to/content",
+        "format" => "guide"
+      },
+      {
+        "title" => "Second Tagged Content",
+        "link" => "/another/link",
+        "format" => "publication"
+      }
+    ]
   end
 end


### PR DESCRIPTION
https://trello.com/c/X8B0CKS8/67-return-all-tagged-content-from-rummager

Previously we were using just the normal search method which only
returns a maximum of 1000 items per search. Some taxons have over
1000 items tagged to them so we needed to return all the items.

The search-enum method return a paginated list of items as an
Enumerable that we can iterate over to display all the items.
This is just a simple change that we can expand on when we know more about the functionality of rummager and have we can leverage it to get back the info that we want.

I have also written up some things that I found you can do with rummager when I was working on this card. It's on the team drive [here](https://docs.google.com/document/d/1puLTN3emfnu9Vv_O4JEQ1YnEDqq0dC5lCE15Vpwz22Q/edit)

