### PR TITLE
Make topic 'See more' link to finder results

### DIFF
--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -17,7 +17,7 @@ module TopicsHelper
 
   def grouped_tagged_content(tagged_content)
     grouped_content = {}
-    
+
     tagged_content.each do |content_item|
       document_format = content_item["format"]
 
@@ -29,5 +29,11 @@ module TopicsHelper
     end
 
     grouped_content.sort_by {|_key, value| value.count}.reverse.to_h
+  end
+
+  def finder_url_and_path(taxon_path, document_type)
+    finder_app_url = ENV['FINDER_APP_URL'] || "https://finder-frontend-pr-411.herokuapp.com/find-all-the-things!11!?"
+    filters = { taxons: taxon_path, content_purpose_document_supertype: document_type }
+    finder_app_url + filters.to_query
   end
 end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -38,7 +38,7 @@
               </li>
             <% end %>
           </ul>
-          <%= link_to("See more", "/topics#{@taxon.base_path}/#{document_type}" ) %>
+          <%= link_to("See more", finder_url_and_path(@taxon.base_path, document_type)) %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
WIP

Amend 'See more' link so that it takes the user to a finder filtered by taxon and document type.

Example:
https://govuk-topic-pages-protot-pr-22.herokuapp.com/topics/education